### PR TITLE
Feat/auth

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,36 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { globalIgnores } from "eslint/config";
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(["dist"]),
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
+    plugins: ["unused-imports"],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
-      reactHooks.configs['recommended-latest'],
+      reactHooks.configs["recommended-latest"],
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      "unused-imports/no-unused-imports-ts": "error",
+      "unused-imports/no-unused-vars-ts": [
+        "warn",
+        {
+          vars: "all",
+          varsIgnorePattern: "^_",
+          args: "after-used",
+          argsIgnorePattern: "^_",
+        },
+      ],
+    },
   },
-])
+]);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "eslint-plugin-unused-imports": "^4.2.0",
     "globals": "^16.3.0",
     "tw-animate-css": "^1.3.7",
     "typescript": "~5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.20
         version: 0.4.20(eslint@9.35.0(jiti@2.5.1))
+      eslint-plugin-unused-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))
       globals:
         specifier: ^16.3.0
         version: 16.3.0
@@ -1279,6 +1282,15 @@ packages:
     resolution: {integrity: sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==}
     peerDependencies:
       eslint: '>=8.40'
+
+  eslint-plugin-unused-imports@4.2.0:
+    resolution: {integrity: sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2911,6 +2923,12 @@ snapshots:
   eslint-plugin-react-refresh@0.4.20(eslint@9.35.0(jiti@2.5.1)):
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
+
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1)):
+    dependencies:
+      eslint: 9.35.0(jiti@2.5.1)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
 
   eslint-scope@8.4.0:
     dependencies:

--- a/src/components/icons/icons.tsx
+++ b/src/components/icons/icons.tsx
@@ -14,6 +14,7 @@ import {
   ShoppingCart,
   Package,
   CheckCircle2,
+  Loader2,
 } from "lucide-react";
 
 export const Icons = {
@@ -32,4 +33,5 @@ export const Icons = {
   shoppingCart: ShoppingCart,
   package: Package,
   checkMarkCircle: CheckCircle2,
+  circleLoader: Loader2,
 };

--- a/src/components/loaders/index.tsx
+++ b/src/components/loaders/index.tsx
@@ -1,0 +1,1 @@
+export { default as PageLoader } from "./pageLoader";

--- a/src/components/loaders/pageLoader.tsx
+++ b/src/components/loaders/pageLoader.tsx
@@ -1,0 +1,15 @@
+import Icon from "../icons";
+
+export default function PageLoader() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-white dark:bg-gray-900 z-50">
+      <div className="flex flex-col items-center gap-4">
+        <Icon
+          name="circleLoader"
+          className="animate-spin h-12 w-12 text-blue-500"
+        />
+        <p className="text-gray-700 dark:text-gray-300 text-lg">Loading...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/user/context.tsx
+++ b/src/contexts/user/context.tsx
@@ -1,0 +1,16 @@
+import type { User } from "@/types/user";
+import { createContext, useContext } from "react";
+
+interface AppUser {
+  user: User;
+}
+
+export const UserContext = createContext<AppUser | undefined>(undefined);
+
+export function useAppUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useAppUser must be used within a UserProvider");
+  }
+  return context;
+}

--- a/src/contexts/user/index.ts
+++ b/src/contexts/user/index.ts
@@ -1,0 +1,2 @@
+export * from './context';
+export * from './provider';

--- a/src/contexts/user/provider.tsx
+++ b/src/contexts/user/provider.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode } from "react";
+
+import { UserContext } from "./context";
+import { PageLoader } from "@/components/loaders";
+import { useFetchMe } from "@/queries/user";
+
+export function AppUserProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const { data: user, isLoading, isError, error: error } = useFetchMe();
+
+  // Clerk or backend is loading
+  if (isLoading) return <PageLoader />;
+
+  // Backend error
+  if (isError) {
+    // Optionally sign out if backend fails
+    console.log("fetch user error", error);
+    return <PageLoader />;
+  }
+
+  return (
+    <UserContext.Provider value={{ user: user! }}>
+      {children}
+    </UserContext.Provider>
+  );
+}

--- a/src/layouts/dashboard/components/sidebar/NavUser.tsx
+++ b/src/layouts/dashboard/components/sidebar/NavUser.tsx
@@ -19,17 +19,17 @@ import {
 import type React from "react";
 import Icon from "@/components/icons";
 import { useMemo } from "react";
-import { getInitials } from "@/utils";
+import { cast, getInitials } from "@/utils";
 import { EXTERNAL_IMAGES } from "@/constants/image";
 import type { User } from "@/types/user";
-import { SignOutButton } from "@clerk/react-router";
+import { SignOutButton, useUser } from "@clerk/react-router";
 
-interface NavUserProps {
-  user: User;
-}
+interface NavUserProps {}
 
-const NavUser: React.FC<NavUserProps> = ({ user }) => {
+const NavUser: React.FC<NavUserProps> = () => {
   const { isMobile } = useSidebar();
+  const { user: clerkUser } = useUser();
+  const user = cast<User>(clerkUser);
   const initials = useMemo(() => getInitials(user), [user]);
   return (
     <SidebarMenu>
@@ -97,8 +97,10 @@ const NavUser: React.FC<NavUserProps> = ({ user }) => {
             <DropdownMenuSeparator />
             <DropdownMenuItem className="cursor-pointer">
               <SignOutButton>
-                <Icon name="logout" className="w-5 h-5" />
-                Log out
+                <div className="contents">
+                  <Icon name="logout" className="w-5 h-5" />
+                  Log out
+                </div>
               </SignOutButton>
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/src/layouts/dashboard/components/sidebar/Sidebar.tsx
+++ b/src/layouts/dashboard/components/sidebar/Sidebar.tsx
@@ -13,12 +13,8 @@ import { cn } from "@/lib/utils";
 import Logo from "./Logo";
 import NavUser from "./NavUser";
 import Icon from "@/components/icons";
-import type { User } from "@/types/user";
 
-interface DashboardSidebarProps {
-  readonly user: User;
-}
-export default function DashboardSidebar({ user }: DashboardSidebarProps) {
+export default function DashboardSidebar() {
   const location = useLocation();
   return (
     <Sidebar collapsible="icon">
@@ -53,7 +49,7 @@ export default function DashboardSidebar({ user }: DashboardSidebarProps) {
         </SidebarMenu>
       </SidebarContent>
       <SidebarFooter className="p-2">
-        <NavUser user={user} />
+        <NavUser />
       </SidebarFooter>
     </Sidebar>
   );

--- a/src/layouts/dashboard/index.tsx
+++ b/src/layouts/dashboard/index.tsx
@@ -1,48 +1,24 @@
-import { Outlet, useNavigate } from "react-router";
+import { Outlet } from "react-router";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import Sidebar from "./components/sidebar";
-import { useFetchMe } from "@/queries/user";
-import { useAuth } from "@clerk/react-router";
-import { useEffect } from "react";
+import { AppUserProvider } from "@/contexts/user";
 
 export default function DashboardLayout() {
-  const { data: user, isLoading, isError } = useFetchMe();
-  const { signOut } = useAuth();
-  const navigate = useNavigate();
-
-  // Handle auth errors or missing user
-  useEffect(() => {
-    if (isError || !user) {
-      signOut({ redirectUrl: "/signin" });
-    }
-  }, [isError, user, signOut]);
-
-  // Redirect to onboarding if needed
-  useEffect(() => {
-    if (user && (!user.orgId || !user.org?.onboardedAt)) {
-      navigate("/onboarding", { replace: true });
-    }
-  }, [user, navigate]);
-
-  if (isLoading) return <div>Loading...</div>;
-
-  if (!user) {
-    return null; // nothing to render until user is loaded or redirect happens
-  }
-
   return (
-    <SidebarProvider>
-      {/* Full height flex container */}
-      <div className="flex h-screen w-screen overflow-hidden bg-gray-50 dark:bg-gray-900 antialiased">
-        {/* Sidebar */}
-        <Sidebar user={user!} />
+    <AppUserProvider>
+      <SidebarProvider>
+        {/* Full height flex container */}
+        <div className="flex h-screen w-screen overflow-hidden bg-gray-50 dark:bg-gray-900 antialiased">
+          {/* Sidebar */}
+          <Sidebar />
 
-        {/* Content area */}
-        <main className="flex flex-col flex-1 min-w-0">
-          <SidebarTrigger className="mb-4" />
-          <Outlet />
-        </main>
-      </div>
-    </SidebarProvider>
+          {/* Content area */}
+          <main className="flex flex-col flex-1 min-w-0">
+            <SidebarTrigger className="mb-4" />
+            <Outlet />
+          </main>
+        </div>
+      </SidebarProvider>
+    </AppUserProvider>
   );
 }

--- a/src/queries/user.ts
+++ b/src/queries/user.ts
@@ -8,5 +8,6 @@ export function useFetchMe() {
     queryFn: () => getMe(),
     select: (data) => data.data,
     staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 1,
   });
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -11,7 +11,7 @@ export interface User extends Base {
   email?: string;
   phone: string;
   role: Role;
-  orgId: string;
+  orgId?: string;
   org?: Org;
   address: Address;
 }

--- a/src/utils/cast.ts
+++ b/src/utils/cast.ts
@@ -1,0 +1,7 @@
+// cast - type-safe casting of values
+// Example usage: const user = cast<User>(clerkUser);
+const cast = <T>(value: unknown): T => {
+  return value as T;
+};
+
+export default cast;

--- a/src/utils/getInitials.ts
+++ b/src/utils/getInitials.ts
@@ -1,7 +1,7 @@
 import type { User } from "@/types/user";
 
 const getInitials = (user: User) => {
-  if (!user.firstName && !user.lastName) return "";
+  if (!user || !user?.firstName || !user.lastName) return "";
 
   const firstName = user.firstName;
   const lastName = user.lastName;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 import getInitials from "@/utils/getInitials";
+import cast from "./cast";
 
-export { getInitials };
+export { getInitials, cast };


### PR DESCRIPTION
## Description

This PR introduces several improvements across layouts, routing, user context, and utilities:

- **ESLint**
  - Attempted to configure ESLint to automatically remove unused variables (unsuccessful).

- **Layouts**
  - Removed `user` prop and its usage from `SidebarNav`.
  - Updated `DashboardLayout` to drop redirect and user fetching logic.
  - Dashboard now uses Clerk user directly in navigation instead of passing `user` prop.

- **Routing**
  - Enhanced `RouteGuard` to include logic for redirecting admins without `orgId` to the onboarding page.

- **Context**
  - Introduced `UserContext` for fetching authenticated users from the backend and making them available throughout the app.

- **Types**
  - Made `orgId` optional in the `User` type.

- **Utils**
  - Added a `cast` utility for type casting.

- **Queries**
  - Added retry logic to `useFetchMe` query.

- **Components**
  - Added a reusable `PageLoader` component for full-page loading states.

## Motivation

- Simplify layouts by removing redundant props and redirect logic.  
- Improve routing by ensuring users are properly redirected to onboarding when required.  
- Provide a centralized way to access backend user data via `UserContext`.  
- Enhance developer experience with utilities, stronger typing, and query reliability.